### PR TITLE
Fix wrong documentation for text.font()

### DIFF
--- a/content/5-elements/default.txt
+++ b/content/5-elements/default.txt
@@ -449,7 +449,7 @@ text.font({
   family:   'Helvetica'
 , size:     144
 , anchor:   'middle'
-, leading:  '1.5em'
+, leading:  '1.5'
 })
 ```
 

--- a/elements/index.html
+++ b/elements/index.html
@@ -1169,7 +1169,7 @@ tspan.animate('2s').fill('#f06')</code></pre>
   family:   'Helvetica'
 , size:     144
 , anchor:   'middle'
-, leading:  '1.5em'
+, leading:  '1.5'
 })</code></pre>
 <p>Not unlike the <code>attr()</code> method, the <code>font()</code> method also accepts a key/value pair:</p>
 <pre><code class="language-javascript">text.font('family', 'Menlo')</code></pre>


### PR DESCRIPTION
Actually, unit `em` for `leading` option is useless.
`leading` will be converted to a number value and used as a multiplier later.
