### PR TITLE
Fix typos + spacing issues

### DIFF
--- a/content/4-container-elements/default.txt
+++ b/content/4-container-elements/default.txt
@@ -29,7 +29,7 @@ var draw = SVG().addTo('#drawing')
 **Note**: The first time `SVG()` is called, a second, invisible `<svg>` will be created. This is our parser (link: /faq text: as explained in the FAQ).
 
 <br>
-An SVG document can also be created inside another SVG document. It is then calle a nested SVG document:
+An SVG document can also be created inside another SVG document. It is then called a nested SVG document:
 
 ## nested() <span class="suffix">constructor</span>
 

--- a/content/4-container-elements/default.txt
+++ b/content/4-container-elements/default.txt
@@ -85,7 +85,7 @@ var use  = draw.use(symbol).move(200, 200)
 <br>
 # SVG.Defs
 
-The `<defs>` element is a container for referenced elements. Descendants of a `<defs>`node are not rendered directly. The `<defs>` node lives in the main `<svg>` document and can be accessed with the `defs()` method.
+The `<defs>` element is a container for referenced elements. Descendants of a `<defs>` node are not rendered directly. The `<defs>` node lives in the main `<svg>` document and can be accessed with the `defs()` method.
 
 ## defs() <span class="suffix">constructor</span>
 

--- a/content/5-shape-elements/default.txt
+++ b/content/5-shape-elements/default.txt
@@ -1412,7 +1412,7 @@ marker.width(10)
 <br>
 # SVG.Style
 
-The Style element creates a style-tag and atts rules for a selector
+The Style element creates a style-tag and adds rules for a selector
 
 ## style() <span class="suffix">constructor</span>
 

--- a/content/5-shape-elements/default.txt
+++ b/content/5-shape-elements/default.txt
@@ -10,7 +10,7 @@ Text:
 
 ### Creating SVG Elements
 
-In svg.js every elements is an object which can be either created by constructing it:
+In svg.js every element is an object which can be either created by constructing it:
 
 ```js
 import { Rect } from "@svgdotjs/svg.js"

--- a/content/5-shape-elements/default.txt
+++ b/content/5-shape-elements/default.txt
@@ -229,7 +229,7 @@ The polyline element defines a set of connected straight line segments. Typicall
 var polyline = draw.polyline('0,0 100,50 50,100').fill('none').stroke({ width: 1 })
 ```
 
-Polyline strings consist of a list of points separated by comma's or spaces. So `x,y x,y x,y` as well as `x y x y x y` or even `x,y,x,y,x,y` will work.
+Polyline strings consist of a list of points separated by commas or spaces. So `x,y x,y x,y` as well as `x y x y x y` or even `x,y,x,y,x,y` will work.
 
 As an alternative, an array of points will work as well:
 

--- a/content/5-shape-elements/default.txt
+++ b/content/5-shape-elements/default.txt
@@ -49,7 +49,7 @@ For all elements that are not described by SVG.js, the `SVG.Dom` class come in h
 
 ## element() <span class="suffix">constructor</span>
 
-`returns` __`SVG.Dom`__ `
+`returns` __`SVG.Dom`__
 
 The `SVG.Dom` class can be instantiated with the `element()` method on any element:
 

--- a/content/5-shape-elements/default.txt
+++ b/content/5-shape-elements/default.txt
@@ -511,7 +511,7 @@ text.length()
 
 `returns` __`itself`__
 
-A convenient method to add font-related properties:
+A convenience method to add font-related properties:
 
 ```javascript
 text.font({

--- a/content/5-shape-elements/default.txt
+++ b/content/5-shape-elements/default.txt
@@ -1412,7 +1412,7 @@ marker.width(10)
 <br>
 # SVG.Style
 
-The Style-element creates a style-tag and atts rules for a selector
+The Style element creates a style-tag and atts rules for a selector
 
 ## style() <span class="suffix">constructor</span>
 

--- a/content/5-shape-elements/default.txt
+++ b/content/5-shape-elements/default.txt
@@ -511,7 +511,7 @@ text.length()
 
 `returns` __`itself`__
 
-A convenience method to add font-related properties:
+A convenient method to add font-related properties:
 
 ```javascript
 text.font({


### PR DESCRIPTION
Just some simple typos etc. 

W/r/t the removal of the hyphen in 'Style-element', none of the other references to element types were hyphenated, so the change has been made for consistency. 

Thanks!