### PR TITLE
Add documentation for 'id'

### DIFF
--- a/content/7-manipulating/default.txt
+++ b/content/7-manipulating/default.txt
@@ -637,6 +637,37 @@ element.visible()
 ```
 
 <br>
+# Id Attribute
+
+The `id()` method allows you to get, and set, the id attribute of SVG elements.
+
+## id() _as getter_
+
+`returns` __`id`__
+
+Gets the id attribute, creating a new unique id if one is not already set:
+
+```javascript
+var id = rect.id()
+```
+
+## id() _as setter_
+
+`returns` __`id`__
+
+Sets the id attribute:
+
+```javascript
+rect.id('my-unique-id')
+```
+
+Removing the id altogether:
+
+```javascript
+rect.id(null)
+```
+
+<br>
 # Class Names
 
 ## addClass()


### PR DESCRIPTION
I was wondering how to set the id of SVG elements. I couldn't find anything in the docs, but after some poking I found `id` does the job.

This (hopefully) adds some minimal documentation. Wasn't positive where to put it, but i popped it near `class`, as in my mind the two are related.

Unfortunately, I couldn't test building the docs, as I couldn't get the site to build.